### PR TITLE
[RM]: Update GitHub action

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out repository code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Install prerequisites
       run: | 
         sudo apt-get --allow-releaseinfo-change update -y && sudo apt-get install -y tox
@@ -20,7 +20,7 @@ jobs:
         tox -e docs
         echo "Building RM in html was successful! "
     - name: Store html build result
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
           name: rm-html
           path: |


### PR DESCRIPTION
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.